### PR TITLE
Relax strict entry rules in TrendStrategy

### DIFF
--- a/lstm_model.py
+++ b/lstm_model.py
@@ -88,9 +88,10 @@ class LSTMPredictor:
         with torch.no_grad():
             pred = self.model(input_tensor).item()
 
-        if pred > 0.1:
+        # 降低判定門檻讓 up/down 訊號更容易出現
+        if pred > 0.05:
             return 1
-        elif pred < -0.1:
+        elif pred < -0.05:
             return -1
         else:
             return 0

--- a/main.py
+++ b/main.py
@@ -11,7 +11,11 @@ from strategies import *  # 匯入所有策略類別
 from datetime import timedelta
 
 # === 載入資料 ===
-real_start = (pd.to_datetime(START_DATE) - timedelta(days=LSTM_LOOKBACK_DAYS)).strftime("%Y-%m-%d")
+# 下載更久以前的資料以確保 LSTM 能取得足夠的訓練樣本
+real_start = (
+    pd.to_datetime(START_DATE)
+    - timedelta(days=LSTM_TRAIN_WINDOW + LSTM_LOOKBACK_DAYS)
+).strftime("%Y-%m-%d")
 df = load_price_data(symbol=STOCK_SYMBOL, start_date=real_start, end_date=END_DATE)
 
 # === 初始化元件 ===

--- a/strategies/trend_strategy.py
+++ b/strategies/trend_strategy.py
@@ -17,14 +17,16 @@ class TrendStrategy(Strategy):
         ma = row["MA"]
         rsi = row["RSI"]
 
-        rsi_low = self.params.get("rsi_low", 30)
-        rsi_high = self.params.get("rsi_high", 70)
+        # 放寬 RSI 門檻以增加交易機會
+        rsi_low = self.params.get("rsi_low", 40)
+        rsi_high = self.params.get("rsi_high", 60)
         allow_short = self.params.get("allow_short", True)
 
         if position is None:
-            if prediction == "up" and close > ma and rsi < rsi_low:
+            # 在無預測時亦可依技術指標進場
+            if (prediction == "up" or prediction is None) and close > ma and rsi < rsi_low:
                 return "Buy"
-            elif prediction == "down" and close < ma and rsi > rsi_high and allow_short:
+            elif allow_short and (prediction == "down" or prediction is None) and close < ma and rsi > rsi_high:
                 return "Short"
 
         elif position == "Long":


### PR DESCRIPTION
## Summary
- allow TrendStrategy to trade on MA and RSI alone when the LSTM prediction is missing
- lower RSI thresholds so entries trigger more often
- download a longer history for LSTM training
- lower the LSTM signal threshold to generate more up/down predictions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684a512ffaa0832897511a5ab7f7387a