### PR TITLE
Enable strategy optimization & fix metrics warning

### DIFF
--- a/optimizer.py
+++ b/optimizer.py
@@ -36,6 +36,17 @@ class StrategyOptimizer:
             trades, _ = sim.simulate(temp_df)
             metrics = sim.calculate_metrics(trades)
 
+            # 計算每日策略報酬以評估 Sharpe Ratio
+            returns = temp_df['close'].pct_change().fillna(0)
+            positions = signals.shift().fillna(0)
+            strat_returns = returns * positions
+            sharpe = (
+                strat_returns.mean() / strat_returns.std() * np.sqrt(252)
+                if strat_returns.std() != 0
+                else 0
+            )
+            metrics['sharpe'] = sharpe
+
             score = self.evaluator(metrics)
             if score > best_score:
                 best_score = score

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -54,8 +54,9 @@ def generate_monthly_report(
     ).reset_index()
 
     # 合併績效與交易統計
-    report = pd.merge(perf.reset_index(drop=True), stats, on="月份", how="left").fillna(0)
-    report["當月交易次數"] = report["當月交易次數"].astype(int)
+    report = pd.merge(perf.reset_index(drop=True), stats, on="月份", how="left")
+    report["當月交易次數"] = report["當月交易次數"].fillna(0).astype(int)
+    report["當月勝率"] = report["當月勝率"].fillna(0)
 
     # === 總體統計 ===
     total_trades = len(trade_log_df)


### PR DESCRIPTION
## Summary
- integrate `StrategyOptimizer` into `main.py` and run when `ENABLE_STRATEGY_OPTIMIZATION` is true
- compute Sharpe ratio inside optimizer to support evaluator
- avoid pandas FutureWarning in `generate_monthly_report`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684a5a4d0d2c8328a12209b999ea90ac