### PR TITLE
Enable strategy optimization and RangeStrategy support/resistance

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ python main.py
 - 回測起訖日期
 - 股票代碼（預設為台灣 0050）
 - 策略選擇與評估依據（如夏普值、勝率、報酬率）
+- 是否啟用策略參數優化（`ENABLE_STRATEGY_OPTIMIZATION`）
 
 ---
 

--- a/strategies/range_strategy.py
+++ b/strategies/range_strategy.py
@@ -15,9 +15,16 @@ class RangeStrategy(Strategy):
         close = row["Close"]
         rsi = row["RSI"]
 
-        # 從參數取得支撐/壓力區間
-        support = self.params.get("support", row["Close"] * 0.95)
-        resistance = self.params.get("resistance", row["Close"] * 1.05)
+        # 從參數取得支撐/壓力區間，若未指定則使用近 N 日高低點
+        window = self.params.get("window", 20)
+        support = self.params.get(
+            "support",
+            data_slice["Close"].rolling(window=window).min().iloc[-1],
+        )
+        resistance = self.params.get(
+            "resistance",
+            data_slice["Close"].rolling(window=window).max().iloc[-1],
+        )
         rsi_low = self.params.get("rsi_low", 50)
         rsi_high = self.params.get("rsi_high", 70)
         allow_short = self.params.get("allow_short", True)


### PR DESCRIPTION
## Summary
- enable and display strategy parameter optimization
- add dynamic support/resistance logic for `RangeStrategy`
- print LLM chosen strategy and notify on strategy change
- mention optimization setting in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py` *(fails: failed to connect to Gemini API)*

------
https://chatgpt.com/codex/tasks/task_e_684a66eb635483288869d92b73027940